### PR TITLE
remove sqlite

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,10 +5,11 @@ const logger = require('morgan');
 const indexRouter = require('./routes/index');
 const analyzeRouter = require('./routes/analyze');
 const usersRouter = require('./routes/users');
+const files = require("./routes/files")
 
 const log = require("./log")
 const app = express();
-
+app.disable('etag');
 app.use(logger('dev'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
@@ -18,7 +19,7 @@ app.use(cookieParser());
 app.use('/api/v1/analyze/', analyzeRouter);
 app.use('/', indexRouter);
 app.use('/api/v1/users/', usersRouter);
-
+app.use('/images/', files);
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {
   res.status(404).json({ok:false, err:"404 not found!"});

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "host":"http://6f4a7fd22d51.ngrok.io",
+    "host":"localhost",
     "mysql":
     {
         "host": "localhost",
@@ -18,7 +18,7 @@
     },
     "mail":
     {
-        "from":"davidsomafiazul@gmail.com"
+       
     }
 
 }

--- a/controllers/leveldb.js
+++ b/controllers/leveldb.js
@@ -1,0 +1,63 @@
+const log       = require("../log")
+const leveldown = require("leveldown");
+const sha256d   = require("../utilities").default.sha256d;
+const db        = leveldown("../tmp/");
+let isWorking = false;
+
+db.open("../tmp/session", (err) =>
+{
+    if(err)
+    {
+        log(err);
+        isWorking = false;
+    }
+    else
+    {
+        log("Session db is working!");
+        isWorking = true;
+    }
+});
+
+exports.db = 
+{
+    createCookie:async (uid) =>
+    {
+        if (!isWorking)
+        {
+            log("Sqlite isn't working", false)
+
+            return -1;
+        }
+        /** @todo that is clearly a bad method */
+        const cookie = await sha256d(`cookie${Math.floor(Math.random() * 123123123123123123123)}`);
+        db.put(cookie, uid, function (err)
+        {
+            if(err)
+            {
+                log(err);
+                isWorking = false;
+            }
+        });
+        return cookie;
+    },
+    deleteCookie: (c) =>
+    {
+        db.del(c, err =>
+        {
+            if(err) log(err);
+        })
+        return true;
+    },
+
+    lookUpCookie:(c, next) =>
+    {
+        db.get(c, (e, v) =>
+        {
+            if(e != null)
+            {
+                next(false); 
+            }
+            else next(v.toString())
+        });
+    },
+};

--- a/controllers/leveldb.js
+++ b/controllers/leveldb.js
@@ -20,7 +20,7 @@ db.open("../tmp/session", (err) =>
 
 exports.db = 
 {
-    createCookie:async (uid) =>
+    createCookie:async (uid, type=0) =>
     {
         if (!isWorking)
         {
@@ -29,7 +29,7 @@ exports.db =
             return -1;
         }
         /** @todo that is clearly a bad method */
-        const cookie = await sha256d(`cookie${Math.floor(Math.random() * 123123123123123123123)}`);
+        const cookie = type + await sha256d(`cookie${Math.floor(Math.random() * 123123123123123123123)}`);
         db.put(cookie, uid, function (err)
         {
             if(err)

--- a/controllers/mysql.js
+++ b/controllers/mysql.js
@@ -127,13 +127,13 @@ exports.db =
       startMysql();
       return next(500, "Mysql isn't work")
     }
-    db.query(`SELECT name, id, type, email, metaInfo, profileImage FROM profile WHERE id="?"`,[uid], function (err, result, fields) {
+    db.query(`SELECT name, id, type, email, metaInfo, profileImage FROM profile WHERE id=?`,[uid], function (err, result, fields) {
     if (err != null)
     {
       if(err.errno == -111) isWorking = false 
         return next(true, err);
-      }
-      if(result.size == 0) return next(true, "Not found"); 
+    }
+      if(result.length == 0) return next(true, "Not found"); 
       else return next(false, result[0])
     });
   },
@@ -211,7 +211,7 @@ exports.db =
       startMysql();
       return next(500, "Mysql isn't work")
     }
-    db.query(`DELETE FROM profile WHERE id="?"`, u , function (err, result, fields) {
+    db.query(`DELETE FROM profile WHERE id=?`, u , function (err, result, fields) {
       if (err != null)
       {
         if(err.errno == -111) isWorking = false 
@@ -282,7 +282,7 @@ exports.db =
   {
     if(!(u && next))
       return next(true);
-    db.query(`UPDATE profile SET isVerified=true WHERE id="?"`,u, function (err, result, fields) {
+    db.query(`UPDATE profile SET isVerified=true WHERE id=?`,u, function (err, result, fields) {
       if (err != null)
       {
         if(err.errno == -111) isWorking = false 

--- a/controllers/mysql.js
+++ b/controllers/mysql.js
@@ -95,7 +95,7 @@ exports.db =
         return next(500, "Mysql isn't work")
       }
 
-    db.query(`SELECT name, metaInfo FROM profile WHERE id="?"`,[uid], function (err, result, fields) {
+    db.query(`SELECT name, metaInfo FROM profile WHERE id=?`,[uid], function (err, result, fields) {
         if (err != null)
         {
           if(err.errno == -111) isWorking = false 
@@ -277,6 +277,29 @@ exports.db =
         }
         next(false);
       });
+  },
+  getUserId: (email, next) =>
+  {
+    if(!email)
+      return ;
+    /** Is the database running? */
+    if (!isWorking)
+    {
+      startMysql();
+      log("Fail to create new analyze, mysql isn't working!", false);
+      next(true);
+      return ;
+    }
+    db.query(`SELECT id FROM profile WHERE email="?"`,[email], (err, v, f) =>
+    {
+      if (err != null)
+      {
+        log(err)
+        if(err.errno == -111) isWorking = false 
+        return next(true);
+      }
+      next(false, v[0]);
+    });
   },
   updateVerificationStatus: (u, next) =>
   {

--- a/log.js
+++ b/log.js
@@ -3,7 +3,7 @@
  * @author: Davidson Souza
  * @date: December, 2020
  */
-
+/**@todo log is an utility */
 const logConf = require("./config.json").logging || false;
 const fs = require("fs")
 var file;

--- a/package.json
+++ b/package.json
@@ -14,11 +14,12 @@
     "express": "^4.16.4",
     "http-errors": "^1.6.3",
     "jade": "~1.11.0",
+    "leveldown": "^5.6.0",
     "morgan": "^1.9.1",
     "multer": "^1.4.2",
     "mysql": "^2.18.1",
     "path": "^0.12.7",
     "sqlite": "^4.0.18",
-    "sqlite3": "^5.0.0"
+    "sqlite3": "^5.0.1"
   }
 }

--- a/routes/files.js
+++ b/routes/files.js
@@ -1,0 +1,30 @@
+var express = require('express');
+var router = express.Router();
+const fs = require("fs");
+router.get("/", (req, res) =>
+{
+    res.end("fkdj");
+})
+
+router.get("/:filename", (req, res) =>
+{
+    if(!(req.params && req.params.filename))
+            return res.status(400).end({ok:false, err:"Missing filename"});
+    
+    fs.readFile(`./uploads/${req.params.filename}`, (e, d) =>
+    {
+        if(e)
+        {
+            res.status(404);
+            return res.end("Not found");
+        }
+        else
+        {
+            res.status(200);
+            res.setHeader("Content-Type", "image/jpg");
+            return res.end(d);
+        }
+    });
+
+})
+module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,6 +3,7 @@ var router = express.Router();
 
 /* GET home page. */
 router.get('/', function(req, res, next) {
+  return res.end("<a href='specklefqormilk:jfdkfje'>aqui</a>");
   res.json({ok:false, err:"Method not allowed!", r:res.finished});
 });
 

--- a/routes/users.js
+++ b/routes/users.js
@@ -48,4 +48,5 @@ router.delete("/deleteUser", controller.deleteUser);
 router.patch("/setProfilePicture", upload.single("profilePic"),controller.uploadProfileImage);
 router.get("/sendVerificationCode", controller.requestConfirmationCode);
 router.get("/verifyCode/:code", controller.verifyCode);
+router.post("/recoveryPassword", controller.recoverPassword);
 module.exports = router;

--- a/test.sh
+++ b/test.sh
@@ -2,7 +2,7 @@
 # Useful variables
 
 echo "Starting some useful tests"
-baseUrl="https://5ac526e53d68.ngrok.io"
+baseUrl="5ac526e53d68.ngrok.io"
 contType="Content-Type: application/json"
 authUser='{"email": "example@email.com", "type":12, "password":"2321", "metaInfo":"something"}'
 createUser='{"name": "linux Is Life", "email": "example@email.com", "type":false, "password":"2321", "metaInfo":"something"}'

--- a/test.sh
+++ b/test.sh
@@ -2,7 +2,7 @@
 # Useful variables
 
 echo "Starting some useful tests"
-baseUrl="localhost:8080"
+baseUrl="https://5ac526e53d68.ngrok.io"
 contType="Content-Type: application/json"
 authUser='{"email": "example@email.com", "type":12, "password":"2321", "metaInfo":"something"}'
 createUser='{"name": "linux Is Life", "email": "example@email.com", "type":false, "password":"2321", "metaInfo":"something"}'

--- a/test.sh
+++ b/test.sh
@@ -43,7 +43,6 @@ then
     echo "Error: Logout"
     exit
 fi
-    
 echo "Deleting the user"
 # Authenticate again
 cookie=$(curl -X POST -H "$contType" -d "$authUser" --silent  $baseUrl/api/v1/users/authenticateUser | jq ".cookie") 

--- a/utilities.js
+++ b/utilities.js
@@ -12,7 +12,7 @@ async function sha256d(chunk)
 {
     return sha256(await sha256(chunk));
 }
-/** @TODO this function is O(n⁴), improve it! */
+/** @TODO this function is O(n⁵), improve it! */
 /** Verify if a passed string is potentially harmful */
 function sanitize(str)
 {
@@ -26,7 +26,7 @@ function sanitize(str)
     for (let i = 0; i<str.length; i++)
     {
         c = str.charAt(i);
-        if((c < '0' || c > 'z') && c != ' ' && c!=',' && c!='@' && c!=".")
+        if((c < '0' || c > 'z') && c != ':'&& c != ' ' && c!=',' && c!='@' && c!=".")
             return -1;
     }
     return 1;


### PR DESCRIPTION
SQlite was initially used to replace loose files in session storage (as PHP does), but it becomes too hard to manage and integrate with some cloud services, hence, I decided to use a more simple but powerful levelDB. More at docs file.